### PR TITLE
fix: show error messages again

### DIFF
--- a/lib/exception.js
+++ b/lib/exception.js
@@ -31,7 +31,7 @@ function AppcException(message, details) {
 	this.details = details ? (Array.isArray(details) ? details : [ details ]) : [];
 }
 
-AppcException.prototype = new Error();
+AppcException.prototype = Object.create(Error.prototype);
 
 /**
  * Logs any additional errors.


### PR DESCRIPTION
Fixing the error messages. Currently it is showing:
```
[ERROR] Error
    at Object.<anonymous> (/Users/miga/Library/Application Support/Titanium/mobilesdk/osx/10.2.0.v20220325163249/node_modules/node-appc/lib/exception.js:34:27)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.get (/Users/miga/Library/Application Support/Titanium/mobilesdk/osx/10.2.0.v20220325163249/node_modules/node-appc/lib/appc.js:62:11)
    at Handle.<anonymous> (/Users/miga/Library/Application Support/Titanium/mobilesdk/osx/10.2.0.v20220325163249/iphone/cli/hooks/install.js:207:22)
    at Handle.emit (events.js:412:35)
```

with this I'm getting the error messages like `Failed to launch iTunes` again.

**Test:**
* attach an ios device
* start a compile to device
* detach the cable while the build is running

I got the hint from this [stackoverflow post](https://stackoverflow.com/a/871646/5193915) and it looks like it has been like this [before](https://github.com/tidev/node-appc/blob/ba568e1bf744f76ac522214ad09c970c392b0d73/lib/exception.js#L32) and it was change to be `new Error()`. It might be a change in node that will show the node error stack instead of our error messages.
`AppcException.prototype = Error.prototype;` works too but according to the SO article it is a "bad form".
