### PR TITLE
fix: handle spaces in deployType and platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '18'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ 14, 16, 17 ]
+        node: [ 18, 20 ]
         os: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:

--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -166,12 +166,12 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 
 				// make sure the module has a valid array of platforms
 				module.platform || (module.platform = params.platforms);
-				Array.isArray(module.platform) || (module.platform = module.platform.split(','));
+				Array.isArray(module.platform) || (module.platform = module.platform.split(',').map(str => str.trim()));
 				// align 'iphone'/'ipad'/'ios' => 'ios'
 				module.platform = Array.from(new Set(module.platform.map(p => platformAliases[p] || p)));
 
 				module.deployType || (module.deployType = params.deployType);
-				Array.isArray(module.deployType) || (module.deployType = module.deployType.split(','));
+				Array.isArray(module.deployType) || (module.deployType = module.deployType.split(',').map(str => str.trim()));
 
 				// if this module doesn't support any of the platforms we're building for, skip it
 				if (!module.deployType.includes(params.deployType)


### PR DESCRIPTION
According to the docs https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Guide/Appendices/tiapp.xml_and_timodule.xml_Reference.html#modules you can use a deploy-type with comma separated values:
```
<module deploy-type="test, production">ti.module</module>
```

BUT you are not allowed to use spaces in between. This PR will trim() the strings so it will ignore the spaces when splitting the value. 
Currently it will compare `production` against `_production` (_ = space) when you use the example above. 

**Workaround**
```
<module deploy-type="test,production">ti.module</module>
```
no space between the text and comma.